### PR TITLE
add lockfile-progs to install deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		locales \
 		debconf-utils \
 		lsb-release \
+		lockfile-progs \
 		file
 
 # install dependencies from Travis


### PR DESCRIPTION
this package is needed by the mainBuilder.sh script during the
assembly step