### PR TITLE
add Makefile for easier builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+DOCKERFILE:=Dockerfile
+POKY?=$(abspath ../poky)
+MAKEFILE:=$(realpath $(lastword $(MAKEFILE_LIST)))
+IMAGE_RECIPE:=console-image
+
+define docker_run
+	docker run \
+		-it \
+		-v ${POKY}:${HOME}/poky \
+		-v ${HOME}/.ssh:${HOME}/.ssh \
+		-v ${MAKEFILE}:${HOME}/Makefile \
+		-e EDITOR=vim \
+		-e POKY=${HOME}/poky \
+		-e TEMPLATECONF=${HOME}/poky/meta-gateway-ww/conf \
+		--rm \
+		${USER}/ww-build-env:latest \
+		$(1)
+endef
+
+.PHONY: all
+all: Makefile .docker-image
+	$(call docker_run, make bb/${IMAGE_RECIPE})
+
+.PHONY: bash
+bash:
+	$(call docker_run, /bin/bash)
+
+.docker-image: ${DOCKERFILE}
+	docker build \
+		--tag ${USER}/ww-build-env:$(shell git describe --dirty --always --tags) \
+		--tag ${USER}/ww-build-env:latest \
+		--build-arg user=${USER} \
+		--build-arg group=${USER} \
+		--build-arg uid=$$(id -u) \
+		--build-arg gid=$$(id -g) \
+		--file ${DOCKERFILE} .
+	touch $@
+
+bitbake-%:
+	$(call docker_run, make bb/$*)
+
+.PHONY: clean
+clean: bitbake-clean
+	rm .docker-image
+
+##
+## The "bb" recipes are meant to be executed from within a Docker container
+##
+.PHONY:bb/%
+bb/%:
+	source ${POKY}/oe-init-build-env ${POKY}/build; \
+	bitbake $*
+
+.PHONY: bb/clean
+bb/clean:
+	source ${POKY}/oe-init-build-env ${POKY}/build; \
+	bitbake -c clean ${IMAGE_RECIPE}

--- a/README.md
+++ b/README.md
@@ -1,45 +1,59 @@
 # Build environment for Wigwag gateway firmware
 
-These instructions assume that this repo is cloned at ~/workspace/wigwag-build-env.  If you cloned the repo at a different location, you will need to make appropriate changes to the commands below.
+This repo contains a set of instructions (this README) and some scripts for building the wigwag gateway firmware image.
 
+The README assumes that the poky repo is cloned in the same directory as this repo.  For example:
 
-## Build the docker image
+    ~/build/
+        wigwag-build-env/
+        poky/
+
+If you cloned the poky repo at a different location, or named the repo a different name, you will need to modify the POKY variable in the Makefile or define the POKY in your shell environment.
+
+## Requirements
+
+    docker
+    build-essential
+
+## Easy Instructions
+
+### Full builds
+
+    make
+
+### Start an interactive Docker container with a bash shell
+
+    make bash
+
+### Build a single package
+
+    make bitbake-<packagename>
+
+### Clean the bitbake environment
+
+    make bitbake-clean
+
+## Harder Instructions
+
+Create a docker container using Dockerfile in this repo and run the container in interactive mode.  Build the firmware image from within Docker.
+
+### Build the docker image
 
     docker build -t wigwag-build-env_${USER} --build-arg user=${USER} --build-arg group=${USER} --build-arg uid=$(id -u) --build-arg gid=$(id -g) .
 
-
-## Run the docker image
+### Run the docker image
 
     docker run -it -v $HOME/workspace:$HOME/workspace -v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK -e EDITOR=vim --name wigwag-build-env_${USER} wigwag-build-env_${USER}
 
 You might also want to run that inside of screen to be able to detach and
 reattach.
 
-## Setup Build Environment
+### Setup Build Environment
+
 These instructions should be run from within the Docker container started in the previous step.
 
-    ssh -T git@github.com
-    mkdir build
-    cd build
-    bash <(curl -fsSLk https://code.wigwag.com/tools/sc/wwysetup.sh)
-    > Github Repository path: /home/<user>/workspace/wigwag-build-env/build
-    > enter
-    ... change yoctoRoot to ${HOME}/workspace/wigwag-build-env/build/Tyocto/
-    ... change assembleRoot to ${HOME}/workspace/wigwag-build-env/build/assemble
-    ... change distrobutionRoot to ${HOME}/workspace/wigwag-build-env/build/distro
-    ... save,quit
-    cd Tyocto/thud/poky
-    # add "export SSH_AUTH_SOCK" without the quotes to build/conf/local.conf
-    echo “1.1.1” > /tmp/BUILDMMU.txt
-    source oe-init-build-env
+    source ../poky/oe-init-build-env ../poky/build
 
-## Auto build with mainBuilder
-    ~/workspace/wigwag-build-env/build/wwbuilds/buildmachine/mainBuilder.sh ~/workspace/wigwag-build-env/build/wwbuilds/buildmachine/configs/thud/mainBuilder.cfg ~/workspace/wigwag-build-env/build/wwbuilds/buildmachine/configs/thud/A20-WigWag-dev.cfg
+### Manual build with bitbake
 
-## Manual build with bitbake
-    bitbake wwrelay-ng-wpackage
-    # TBD assembly steps
-
-## Troubleshooting
-
-1.  Any time the docker container is rebuilt, you must run "ssh -T git@github.com" and accept the github server's pubkey before running bitbake again.
+    bitbake console-image


### PR DESCRIPTION
Running make with no parameters will create a docker container
from Dockerfile and run bitbake inside the container.