### PR TITLE
Setup $HOME/.ssh/known_hosts when the container is built

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,5 +80,11 @@ RUN groupadd -g ${gid} ${group} \
 && sed -i 's/%sudo	ALL=(ALL:ALL) ALL/%sudo	ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers
 
 USER ${user}
+
+# accept the host key for github
+RUN mkdir ${HOME}/.ssh \
+&& chmod 700 ${HOME}/.ssh \
+&& ssh-keyscan -H github.com > ${HOME}/.ssh/known_hosts
+
 WORKDIR /home/${user}
 CMD /bin/bash

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ reattach.
 ## Setup Build Environment
 These instructions should be run from within the Docker container started in the previous step.
 
-    ssh -T git@github.com
     mkdir build
     cd build
     bash <(curl -fsSLk https://code.wigwag.com/tools/sc/wwysetup.sh)
@@ -39,7 +38,3 @@ These instructions should be run from within the Docker container started in the
 ## Manual build with bitbake
     bitbake wwrelay-ng-wpackage
     # TBD assembly steps
-
-## Troubleshooting
-
-1.  Any time the docker container is rebuilt, you must run "ssh -T git@github.com" and accept the github server's pubkey before running bitbake again.


### PR DESCRIPTION
Automatically populate $HOME/.ssh/known_hosts during docker build so
that clones from github.com will automatically work without having to
accept the host key.