### PR TITLE
Map SSH_AUTH_SOCK volume and env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ define docker_run
 		-v ${POKY}:${HOME}/poky \
 		-v ${HOME}/.ssh:${HOME}/.ssh \
 		-v ${MAKEFILE}:${HOME}/Makefile \
+		-v $$(dirname $$SSH_AUTH_SOCK):$$(dirname $$SSH_AUTH_SOCK) \
+		-e SSH_AUTH_SOCK=$$SSH_AUTH_SOCK \
 		-e EDITOR=vim \
 		-e POKY=${HOME}/poky \
 		-e TEMPLATECONF=${HOME}/poky/meta-gateway-ww/conf \


### PR DESCRIPTION
This will allow us to authenticate to git servers using ssh-agent.
This is especially useful when the ssh private key is encrypted with
a passphrase.