### PR TITLE
Enable using loopback mount points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,15 @@ IMAGE_RECIPE:=console-image
 
 define docker_run
 	docker run \
+		--privileged=true \
+		--device /dev/loop0:/dev/loop0 \
+		--device /dev/loop1:/dev/loop1 \
+		--device /dev/loop2:/dev/loop2 \
+		--device /dev/loop3:/dev/loop3 \
+		--device /dev/loop4:/dev/loop4 \
+		--device /dev/loop5:/dev/loop5 \
+		--device /dev/loop6:/dev/loop6 \
+		--device /dev/loop7:/dev/loop7 \
 		-it \
 		-v ${POKY}:${HOME}/poky \
 		-v ${HOME}/.ssh:${HOME}/.ssh \


### PR DESCRIPTION
This will allow us to mount partitions from .wic files inside a
Docker container.

Signed-off-by: Cristian Prundeanu <cristian.prundeanu@arm.com>