### PR TITLE
Dockerfile: add rsync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		lsb-release \
 		lockfile-progs \
 		pxz \
+		rsync \
 		file
 
 # install dependencies from Travis


### PR DESCRIPTION
the factory update creator script in the tools repo needs rsync
in order to diff two builds.