### PR TITLE
add mkimage to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,6 +107,10 @@ RUN dpkg --add-architecture i386 \
 		libcrypto++-dev:i386 \
 		zlib1g-dev:i386
 
+# additional build utilities
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        u-boot-tools
+
 # if we're building a jenkins agent, we must also install openjdk
 # and an ssh server so the master can log in
 ARG mode

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ all: Makefile .docker-image conf
 	$(call docker_run, make bb/${IMAGE_RECIPE})
 
 .PHONY: bash
-bash:
+bash: .docker-image
 	$(call docker_run, /bin/bash)
 
 .docker-image: ${DOCKERFILE}


### PR DESCRIPTION
for building and testing uboot images, we need the mkimage
utility which is included in the u-boot-tools package.