### PR TITLE
Support FIT keys and FIP keys and certs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,25 @@ endef
 
 .PHONY: all
 all: Makefile .docker-image conf
-	cp ./mbed_cloud_dev_credentials.c ${POKY}/meta-pelion-edge/recipes-wigwag/mbed-edge-core/files/
-	cp ./upgradeCA.cert ${POKY}/meta-pelion-edge/recipes-core/ww-console-image-initramfs-init/files/
-	cp ./update_default_resources.c ${POKY}/meta-pelion-edge/recipes-wigwag/mbed-edge-core/files/
+	if [ -e ./mbed_cloud_dev_credentials.c ]; then \
+		cp ./mbed_cloud_dev_credentials.c  ${POKY}/meta-pelion-edge/recipes-wigwag/mbed-edge-core/files/; \
+	fi
+	if [ -e ./upgradeCA.cert ]; then \
+		cp ./upgradeCA.cert ${POKY}/meta-pelion-edge/recipes-core/ww-console-image-initramfs-init/files/; \
+	fi
+	if [ -e ./update_default_resources.c ]; then \
+		cp ./update_default_resources.c ${POKY}/meta-pelion-edge/recipes-wigwag/mbed-edge-core/files/; \
+	fi
+	if [ -e ./rot_key.pem ]; then \
+		mkdir -p ${POKY}/meta-pelion-edge/recipes-bsp/atf/files/; \
+		cp ./rot_key.pem ${POKY}/meta-pelion-edge/recipes-bsp/atf/files/; \
+	fi
+	if [ -e ./mbl-fit-rot-key.crt ]; then \
+		cp ./mbl-fit-rot-key.crt ${POKY}/build/; \
+	fi
+	if [ -e ./mbl-fit-rot-key.key ]; then \
+		cp ./mbl-fit-rot-key.key ${POKY}/build/; \
+	fi
 	$(call docker_run, make bb/${IMAGE_RECIPE})
 
 .PHONY: bash

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Build environment for Pelion OS Edge firmware
 
 This repo contains a set of instructions (this README) and some scripts for building the Pelion OS Edge firmware image.
-When used in conjuction with the [Repo Manifest](https://github.com/armpelionedge/manifest-pelion-os-edge) repository, it automates the complete [Yocto build instructions](https://github.com/armpelionedge/meta-pelion-os-edge/blob/master/BUILD.md).
+When used in conjuction with the [Repo Manifest](https://github.com/armpelionedge/manifest-pelion-os-edge) repository, it automates the complete [Yocto build instructions](https://github.com/armpelionedge/meta-pelion-edge/blob/dev/BUILD.md).
 
 The README assumes that the poky repo is cloned in the same directory as this repo.  For example:
 
@@ -21,18 +21,14 @@ If you cloned the poky repo at a different location, or named the repo a differe
 ## Easy Instructions
 
 ### Credentials
-   Three sets of credentials are needed for inclusion in the firware image. If they are present in this directory, the Makefile will copy them to the appropriate location for the yocto build.
+   Several sets of credentials are needed to build the firware image. If they are present in this directory, the Makefile will copy them to the appropriate location for the yocto build.  Please consult the [Yocto build instructions](https://github.com/armpelionedge/meta-pelion-edge/blob/dev/BUILD.md) for more information about these credentials.
 
-#### Pelion Development Credentials
-
-   Pelion Cloud development credentials are needed for Pelion Edge.  Provision your build with a Pelion Cloud developer certificate if you are building for [Pelion Cloud developer mode](https://cloud.mbed.com/docs/current/connecting/provisioning-development-devices.html).  Copy your Pelion Cloud credentials file to this directory.
-
-#### Upgrade CA Certificate
-   Authenticated upgrade requires inclusion of a cerificate authority certificate to be included in the initialization image.   This CA is used to issue the certificates included with an authenticated upgrade.  After obtaining your CA certificate, copy to the local file ./upgradeCA.cert.
-
-#### Firmware Update Manifest Credentials
-
-   If you enabled support for Pelion firmware updates in mbed-edge-core, copy your manifest certificate update_default_resources.c into `recipes-wigwag/mbed-edge-core/files/`.  Run manifest-tool to generate the certificate.  See the documentation on [getting the update resources](https://github.com/ARMmbed/mbed-edge/blob/master/README.md#getting-the-update-resources).
+	* mbed_cloud_dev_credentials.c
+	* upgradeCA.cert
+	* update_default_resources.c
+	* rot_key.pem
+	* mbl-fit-rot-key.cert
+	* mbl-fit-rot-key.key
 
 ### Full builds
 


### PR DESCRIPTION
The FIP keys/certs are used to sign and validate fip2.bin which
contains uboot, and the FIT key is used to validate each of the
images contained within the Verified UBoot FIT image.

Please see the meta-pelion-edge BUILD doc for more info.